### PR TITLE
bump to latest okhttp and add apache client as a default retrofit dependency

### DIFF
--- a/src/spinnaker-dependencies.yml
+++ b/src/spinnaker-dependencies.yml
@@ -25,7 +25,7 @@ versions:
   junit: "4.12"
   lombok: "1.16.4"
   objenesis: "2.2"
-  okHttp: "2.2.0"
+  okHttp: "2.7.0"
   redisEmbedded: "0.6"
   retrofit: "1.9.0"
   rxJava: "1.0.16"
@@ -90,6 +90,7 @@ groups:
       - retrofit
       - okHttp
       - okHttpUrlconnection
+      - okHttpApache
       - retrofitJackson
     testCompile:
       - retrofitMock
@@ -177,6 +178,7 @@ dependencies:
   objenesis: "org.objenesis:objenesis:${versions.objenesis}"
   okHttp: "com.squareup.okhttp:okhttp:${versions.okHttp}"
   okHttpUrlconnection: "com.squareup.okhttp:okhttp-urlconnection:${versions.okHttp}"
+  okHttpApache: "com.squareup.okhttp:okhttp-apache:${versions.okHttp}"
   redisEmbedded: "com.github.kstyrc:embedded-redis:${versions.redisEmbedded}"
   retrofit: "com.squareup.retrofit:retrofit:${versions.retrofit}"
   retrofitJackson: "com.squareup.retrofit:converter-jackson:${versions.retrofit}"


### PR DESCRIPTION
Newer okHttp fails on empty PUT and was coming in transitively from kubernetes-client .. bump to the newest version and add apache client support to handle empty PUTs