### PR TITLE
fix(kork) - bump kork version to 1.87.0

### DIFF
--- a/src/spinnaker-dependencies.template
+++ b/src/spinnaker-dependencies.template
@@ -1,7 +1,7 @@
 versions:
 # spinnaker libs
   fiat: "0.11.0"
-  kork: "1.86.0"
+  kork: "1.87.0"
   scheduledActions: "0.38.0"
   clouddriver: "1.545.0"
   front50: "1.72.0"

--- a/src/spinnaker-dependencies.yml
+++ b/src/spinnaker-dependencies.yml
@@ -1,7 +1,7 @@
 versions:
 # spinnaker libs
   fiat: "0.11.0"
-  kork: "1.86.0"
+  kork: "1.87.0"
   scheduledActions: "0.38.0"
   clouddriver: "1.545.0"
   front50: "1.72.0"


### PR DESCRIPTION
adds support for improved TLS configuration for tomcat where SSL is enabled

(depends on https://github.com/spinnaker/kork/pull/75 release)