### PR TITLE
chore(dependencies): Bump clouddriver and add clouddriver-oracle-bmcs…

### DIFF
--- a/src/spinnaker-dependencies.template
+++ b/src/spinnaker-dependencies.template
@@ -3,7 +3,7 @@ versions:
   fiat: "0.11.0"
   kork: "1.91.0"
   scheduledActions: "0.38.0"
-  clouddriver: "1.545.0"
+  clouddriver: "1.601.0"
   front50: "1.72.0"
 # third party
   akka: "2.3.9"
@@ -156,6 +156,7 @@ dependencies:
   clouddriverKubernetes: "com.netflix.spinnaker.clouddriver:clouddriver-kubernetes:${versions.clouddriver}"
   clouddriverOpenstack: "com.netflix.spinnaker.clouddriver:clouddriver-openstack:${versions.clouddriver}"
   clouddriverTitus: "com.netflix.spinnaker.clouddriver:clouddriver-titus:${versions.clouddriver}"
+  clouddriverOracleBmcs: "com.netflix.spinnaker.clouddriver:clouddriver-oracle-bmcs:${versions.clouddriver}"
   fiat: "com.netflix.spinnaker.fiat:fiat-api:${versions.fiat}"
   front50Gcs: "com.netflix.spinnaker.front50:front50-gcs:${versions.front50}"
   front50S3: "com.netflix.spinnaker.front50:front50-s3:${versions.front50}"

--- a/src/spinnaker-dependencies.yml
+++ b/src/spinnaker-dependencies.yml
@@ -3,7 +3,7 @@ versions:
   fiat: "0.11.0"
   kork: "1.91.0"
   scheduledActions: "0.38.0"
-  clouddriver: "1.545.0"
+  clouddriver: "1.601.0"
   front50: "1.72.0"
 # third party
   akka: "2.3.9"
@@ -156,6 +156,7 @@ dependencies:
   clouddriverKubernetes: "com.netflix.spinnaker.clouddriver:clouddriver-kubernetes:${versions.clouddriver}"
   clouddriverOpenstack: "com.netflix.spinnaker.clouddriver:clouddriver-openstack:${versions.clouddriver}"
   clouddriverTitus: "com.netflix.spinnaker.clouddriver:clouddriver-titus:${versions.clouddriver}"
+  clouddriverOracleBmcs: "com.netflix.spinnaker.clouddriver:clouddriver-oracle-bmcs:${versions.clouddriver}"
   fiat: "com.netflix.spinnaker.fiat:fiat-api:${versions.fiat}"
   front50Gcs: "com.netflix.spinnaker.front50:front50-gcs:${versions.front50}"
   front50S3: "com.netflix.spinnaker.front50:front50-s3:${versions.front50}"


### PR DESCRIPTION
… dependency

Bump clouddriver from 1.545.0 to 1.601.0 (latest)

Clouddriver-oracle-bmcs module doesn't exist before clouddriver 1.573.0 so i thought it best to bump it to latest (1.601.0).