### PR TITLE
chore(*): rxJava 1.3.8

### DIFF
--- a/src/spinnaker-dependencies.template
+++ b/src/spinnaker-dependencies.template
@@ -45,7 +45,7 @@ versions:
   okHttp: "2.7.0"
   redisEmbedded: "0.7.0"
   retrofit: "1.9.0"
-  rxJava: "1.0.16"
+  rxJava: "1.3.8"
   slf4j: "{{org.slf4j:slf4j-api}}"
   snappy: "{{org.xerial.snappy:snappy-java}}"
   spectator: "0.57.1"

--- a/src/spinnaker-dependencies.yml
+++ b/src/spinnaker-dependencies.yml
@@ -45,7 +45,7 @@ versions:
   okHttp: "2.7.0"
   redisEmbedded: "0.7.0"
   retrofit: "1.9.0"
-  rxJava: "1.0.16"
+  rxJava: "1.3.8"
   slf4j: "1.7.25"
   snappy: "1.1.2.6"
   spectator: "0.57.1"


### PR DESCRIPTION
This is the latest in the 1.x rxJava branch, now EOL'ed.

The primary driver for updating is the fix for this issue:
https://github.com/ReactiveX/RxJava/issues/2297#issuecomment-204431103