### PR TITLE
chore(kork): bump kork to 3.4.0

### DIFF
--- a/src/spinnaker-dependencies.template
+++ b/src/spinnaker-dependencies.template
@@ -1,7 +1,7 @@
 versions:
 # spinnaker libs
   fiat: "0.53.0"
-  kork: "3.2.8"
+  kork: "3.4.0"
   scheduledActions: "0.39.0"
   clouddriver: "2.110.1"
   front50: "1.139.0"

--- a/src/spinnaker-dependencies.yml
+++ b/src/spinnaker-dependencies.yml
@@ -1,7 +1,7 @@
 versions:
 # spinnaker libs
   fiat: "0.53.0"
-  kork: "3.2.8"
+  kork: "3.4.0"
   scheduledActions: "0.39.0"
   clouddriver: "2.110.1"
   front50: "1.139.0"


### PR DESCRIPTION
And the bumping cycle continues. Needed to bump kork to use the latest spin dependencies. Now bumping here to use the latest kork. The circle of life continues.