### PR TITLE
fix(*): Align JUnit vintage with Jupiter version

### DIFF
--- a/src/spinnaker-dependencies.yml
+++ b/src/spinnaker-dependencies.yml
@@ -37,9 +37,9 @@ versions:
   jooq: "3.9.6"
   jsonPath: "2.2.0" # "2.2.0"
   junit: "4.12"
-  junitVintage: "4.12.3"
   junit5: "1.3.2"
   jupiter: "5.3.2"
+  junitVintage: "5.3.2" # deprecated: this should always align to 'jupiter' version
   kotlin: "1.3.20"
   kotlinCoroutines: "1.1.1"
   lombok: "1.16.20" # "1.16.22"


### PR DESCRIPTION
Ultimately we should eliminate the usage of `junitVintage` everywhere since this version should always be aligned to Jupiter.